### PR TITLE
Simplify base::Thread::start template parameters

### DIFF
--- a/base/threading.h
+++ b/base/threading.h
@@ -51,7 +51,7 @@ public:
   template <typename F, typename... Ts>
   Thread(F&& func, Ts&&... args) {
     pthread_attr_init(&attributes_);
-    pthread_create(&id_, &attributes_, start<Ts...>,
+    pthread_create(&id_, &attributes_, start<ThreadArg<Ts...>>,
                    new ThreadArg<Ts...>(std::forward<F>(func),
                                         std::forward<Ts>(args)...));
   }
@@ -64,9 +64,9 @@ public:
     pthread_join(id_, nullptr);
   }
 
-  template <typename... Ts>
+  template <typename Arg>
   static void* start(void* in) {
-    std::unique_ptr<ThreadArg<Ts...>> thread_arg((ThreadArg<Ts...>*)in);
+    std::unique_ptr<Arg> thread_arg((Arg*)in);
     CHECK(thread_arg);
 
     helper::invoker(thread_arg->f, thread_arg->args);


### PR DESCRIPTION
Actually no, this PR is very subtle and I should've documented it more. I'll provide the documentation in this comment, and edit the original comment of this PR to include the text as well:

The base::Thread class has a static `start` method, which is the first function that `pthread_create` runs on the new thread. pthreads require this starter function to take in a single `void*`, however obviously we want to transport a variadic number of arguments, and invoke the "real" function that the user supplied. We use the `ThreadArg` class to carry and forward a function and its intended arguments. Since `ThreadArg` carries a variadic number of arguments, it has a `std::tuple<Ts...> args;` member to carry these args, where `Ts...` is a template parameter pack, which is required to supply when creating an instance of this class.

**Before this PR**: base::Thread::start had a template parameter which was a template parameter pack. It represented the `Ts...` used to recover the `ThreadArg` from the `void*` input. However, if you accidentally write:

```pthread_create(..., ..., start, thread_arg)```

...instead of...

```pthread_create(..., ..., start<Ts...>, thread_arg)```

The template parameter pack is not carried through, and `start` infers an empty argument list, causing undefined behavior when the user-supplied start method is run. This is very error-prone, and I had a hard time finding the mistake before pushing up the correct code (second example above).

**After this PR**: Instead of base::Thread::start having a template parameter pack which is omissible and error-prone if omitted, it has a template parameter _type_, which cannot be omitted. Now, you are forced to write:

```pthread_create(..., ..., start<ThreadArg<Ts...>>, thread_arg)```

Which will always work, and will not compile if you omit the template parameter type in `start` above. This makes the code more obvious and less error-prone. I learned about this issue via Jeffrey Yasskin at Google, who knows way too much about C++.