### PR TITLE
Add macOS target to bazel build file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,3 +6,30 @@ http_archive(
   sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
   strip_prefix = "googletest-release-1.10.0",
 )
+
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "build_bazel_rules_apple",
+    remote = "https://github.com/bazelbuild/rules_apple.git",
+    tag = "0.19.0",
+)
+
+git_repository(
+    name = "build_bazel_rules_swift",
+    remote = "https://github.com/bazelbuild/rules_swift.git",
+    tag = "0.13.0",
+)
+
+git_repository(
+    name = "build_bazel_apple_support",
+    remote = "https://github.com/bazelbuild/apple_support.git",
+    tag = "0.7.2",
+)
+
+git_repository(
+    name = "bazel_skylib",
+    remote = "https://github.com/bazelbuild/bazel-skylib.git",
+    tag = "0.9.0",
+)

--- a/content/BUILD
+++ b/content/BUILD
@@ -1,4 +1,26 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@build_bazel_rules_apple//apple:macos.bzl", "macos_application")
+load("@build_bazel_rules_apple//apple:versioning.bzl", "apple_bundle_version")
+
+apple_bundle_version(
+    name = "myAppVersion",
+    build_version = "1.0",
+)
+
+objc_library(
+    name = "Sources",
+    srcs = [
+        "main.m",
+    ]
+)
+
+macos_application(
+  name = "myApp",
+  bundle_id = "myID",
+  minimum_os_version = "10.11",
+  infoplists = [":info.plist"],
+  deps = ["Sources"],
+)
 
 cc_binary(
   name = "main",

--- a/content/info.plist
+++ b/content/info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 The Bazel Authors. All rights reserved.</string>
+	<key>NSMainStoryboardFile</key>
+	<string>Main</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+</dict>
+</plist>

--- a/content/main.cc
+++ b/content/main.cc
@@ -74,6 +74,7 @@ void consumer(std::queue<std::string>& q, base::Mutex& mutex,
 }
 
 int main() {
+
   srand(time(NULL));
   base::Mutex mutex(base::ThreadMode::kUsingPthread);
   base::ConditionVariable condition(base::ThreadMode::kUsingPthread);

--- a/content/main.m
+++ b/content/main.m
@@ -1,0 +1,15 @@
+#import <Cocoa/Cocoa.h>
+
+int main(int argc, const char * argv[]) {
+  [NSApplication sharedApplication];
+  [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+  id applicationName = [[NSProcessInfo processInfo] processName];
+  id window = [[NSWindow alloc] initWithContentRect:NSMakeRect(0, 0, 600, 600)
+                                          styleMask:NSTitledWindowMask backing:NSBackingStoreBuffered defer:NO];
+  [window cascadeTopLeftFromPoint:NSMakePoint(20,20)];
+  [window setTitle: applicationName];
+  [window makeKeyAndOrderFront:nil];
+  [NSApp activateIgnoringOtherApps:YES];
+  [NSApp run];
+  return 0;
+}


### PR DESCRIPTION
Addresses https://github.com/domfarolino/browser/issues/14

Kind of a proof of concept, might need to refine this PR before merging.

I had to unzip the App folder for some reason, not sure why.

```
bazel build content/myApp
cd ./bazel-bin/content
unzip myApp.zip
./myApp.app/Contents/MacOS/myApp
```