### PR TITLE
Introduce TaskLoopForUI as a pass-through

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -19,6 +19,7 @@ cc_library(
     "scheduling/scheduling_handles.h",
     "scheduling/task_loop.h",
     "scheduling/task_loop_for_io.h",
+    "scheduling/task_loop_for_ui.h",
     "scheduling/task_loop_for_worker.h",
     "scheduling/task_runner.h",
     "synchronization/condition_variable.h",

--- a/base/scheduling/task_loop.cc
+++ b/base/scheduling/task_loop.cc
@@ -8,6 +8,7 @@
 #if defined(OS_MACOS)
 #include "base/scheduling/task_loop_for_io.h"
 #endif
+#include "base/scheduling/task_loop_for_ui.h"
 #include "base/scheduling/task_loop_for_worker.h"
 
 namespace base {
@@ -16,7 +17,6 @@ void TaskLoop::BindToCurrentThread(ThreadType type) {
   // Depending on |type|, create a process-global pointer to |this|.
   switch (type) {
     case ThreadType::UI:
-      NOTREACHED();
       CHECK(!GetUIThreadTaskLoop());
       SetUIThreadTaskLoop(GetWeakPtr());
       CHECK(GetUIThreadTaskLoop());
@@ -41,11 +41,8 @@ void TaskLoop::BindToCurrentThread(ThreadType type) {
 // static
 std::shared_ptr<TaskLoop> TaskLoop::CreateUnbound(ThreadType type) {
   switch (type) {
-    case ThreadType::WORKER:
-      return std::shared_ptr<TaskLoopForWorker>(new TaskLoopForWorker());
     case ThreadType::UI:
-      NOTREACHED();
-      return std::shared_ptr<TaskLoopForWorker>();
+      return std::shared_ptr<TaskLoopForUI>(new TaskLoopForUI());
     case ThreadType::IO:
 #if defined(OS_MACOS)
       return std::shared_ptr<TaskLoopForIO>(new TaskLoopForIO());
@@ -53,6 +50,8 @@ std::shared_ptr<TaskLoop> TaskLoop::CreateUnbound(ThreadType type) {
       NOTREACHED();
       return std::shared_ptr<TaskLoopForWorker>();
 #endif
+    case ThreadType::WORKER:
+      return std::shared_ptr<TaskLoopForWorker>(new TaskLoopForWorker());
   }
 
   NOTREACHED();

--- a/base/scheduling/task_loop_for_ui.h
+++ b/base/scheduling/task_loop_for_ui.h
@@ -1,0 +1,20 @@
+#ifndef BASE_SCHEDULING_TASK_LOOP_FOR_UI_H_
+#define BASE_SCHEDULING_TASK_LOOP_FOR_UI_H_
+
+// For now, TaskLoopForUI is just a pass-through to TaskLoopForWorker since we
+// don't really support UI capabilities just yet. Once we implement a real UI
+// thread along with UI event listening mechanics, then we can implement a real
+// TaskLoopForUI, and swap out the implementation here.
+
+#include "base/build_config.h"
+
+#include "base/scheduling/task_loop_for_worker.h"
+
+namespace base {
+
+// TODO(domfarolino): Implement a real TaskLoopForUI and reference it here.
+using TaskLoopForUI = TaskLoopForWorker;
+
+} // namespace base
+
+#endif // BASE_SCHEDULING_TASK_LOOP_FOR_UI_H_

--- a/base/scheduling/task_loop_test.cc
+++ b/base/scheduling/task_loop_test.cc
@@ -215,11 +215,11 @@ TEST_P(TaskLoopTest, RunUntilIdleDoesNotSnapshotTheEventQueueSize) {
 #if defined(OS_MACOS)
 INSTANTIATE_TEST_SUITE_P(TaskLoopTest,
                          TaskLoopTest,
-                         testing::Values(ThreadType::WORKER, ThreadType::IO));
+                         testing::Values(ThreadType::UI, ThreadType::IO, ThreadType::WORKER));
 #else
 INSTANTIATE_TEST_SUITE_P(TaskLoopTest,
                          TaskLoopTest,
-                         testing::Values(ThreadType::WORKER));
+                         testing::Values(ThreadType::UI, ThreadType::WORKER));
 #endif
 
 }; // namespace base


### PR DESCRIPTION
For simplicity, this PR introduces TaskLoopForUI as a pass-through for TaskLoopForWorker. This allows us to write generic tests against TaskLoopForUI in the meantime, and then when we introduce a real backing implementation for TaskLoopForUI, we have less special-case places to go back and modify.