### PR TITLE
Fix various threading bugs and add tests

### DIFF
--- a/base/threading/thread.cc
+++ b/base/threading/thread.cc
@@ -45,7 +45,8 @@ std::shared_ptr<TaskRunner> Thread::GetTaskRunner() {
 void Thread::Stop() {
   // We can't CHECK(started_via_api_) here because Stop() should be idempotent.
   // If |started_via_api_| is false then we don't want to do anything here
-  // because that means we've already called Stop() or join(), in which case:
+  // because that means we've already called Stop() or join() (or we've never
+  // called Start()), in which case:
   //   - |delegate_| has already been reset, so there is nothing to Quit()
   //   - The backing thread has already been terminated, so there is nothing to join
   if (!started_via_api_) {

--- a/base/threading/thread.h
+++ b/base/threading/thread.h
@@ -61,10 +61,10 @@ class Thread {
 
  protected:
   // These methods run on the newly-created thread.
-  // This method is run for the duration of the underlying thread's lifetime.
-  // When it exits, the thread is terminated.
+  // This method is run for the duration of the backing thread's lifetime. When
+  // it exits, the thread is terminated.
   static void* ThreadFunc(void* in);
-  // This method invokes |Delegate::Run()|.
+  // This method invokes |Delegate::Run()| on the the backing physical thread.
   void ThreadMain();
 
   // NOTE: Never hand out any std::shared_ptr copies of this member! This is
@@ -78,6 +78,7 @@ class Thread {
   //   - ThreadFunc() => when |delegate_->Run()| finishes, |delegate_| is
   //     reset/destroyed. This means that |delegate_| is reset after calls to
   //     Stop()/join().
+  // TODO(domfarolino): Add a mutex to synchronize access to this variable.
   std::shared_ptr<Delegate> delegate_;
 
  private:


### PR DESCRIPTION
This PR does the following:
 - Rename base::Thread::Quit() to base::Thread::Stop() and make it call join() as well, waiting for the underlying physical thread to exit.
    - This is important because if Stop() does not also join(), we can get some weird errors that this PR adds tests for. For example, an immediate sequence of Start() => Stop() => Start() => Stop() often leads to a weird race condition: The actual effects of Start() (that is, calling TaskLoop::Run() on the new physical thread) happen asynchronously but Stop() takes effect immediately by just setting the underlying TaskLoop's `quit_` variable from the outer/main thread. This caused a race condition where both Stop() calls were completely finished before the first `Run()` was invoked on the new thread. Therefore the first call observed the `quit_`, and immediately exited and reset the `quit_` variable. The second `Run()` call happened on a new physical thread and observed that `quit_ == false`, and so it waited indefinitely for new tasks. This is pretty bad, so we fix this / fix #41 and add tests.
 - The above point is not the only case where we could have two physical threads invoked on the same base::Thread::Delegate at the same time. Before this PR you could simply call base::Thread::Start() twice in a row without ever calling Stop()/Quit() even once. This was a major oversight, so we add a boolean `base::Thread::started_` to keep track of whether or not the thread has been started or not, and CHECK() if we try to start an already-started thread. The actual semantics look like so:
    - base::Thread::Start() checks `!started_`, and sets `started_ = true`
    - base::Thread::Stop() sets `started_ = false`, but does not CHECK the status of `started_`. This is because Stop() should be idempotent.
    - base::Thread::join() sets `started_ = false` because if the underlying physical thread actually stops and eventually joins(), it is considered officially stopped and should be able to be restarted.
- ~Allows TaskLoop::BindToCurrentThread() to be called multiple times from the same TaskLoop.~
    - ~Before this PR, subsequent TaskLoop::BindToCurrentThread() calls on the same TaskLoop would crash due to `CHECK(!Get{UI,IO}ThreadTaskLoop());`, because the UI/IO process-global TaskLoops would already exist. Really this just means the BindToCurrentThread() is a misnomer because not only does it bind the current TaskLoop to the `thread_local` TaskLoop member, but it also binds the process-wide pointers if applicable (that is, only for UI/IO threads).~
    - ~To make this work, we loosen the CHECK to `CHECK(!GetUIThreadTaskLoop() || GetUIThreadTaskLoop().get() == this);`. This allows the method to be called multiple times on the same TaskLoop.~
    - ~This is important because after a base::Thread's physical thread is shut down and joined, it does not reset its delegate, so the process-global UI/IO TaskLoop pointers persist, even though the `thread_local` slot is cleared because the underlying physical thread is gone. So when we restart the thread, we need to re-bind the TaskLoop to the `thread_local` slot, even ifthe process-global TaskLoop pointers may persist.~

This PR also makes it such that when a base::Thread is stopped. In other words, the backing physical thread can self-terminate, and the owning thread can also self-terminate, but the owning thread cannot "pause" the thread by quitting and restarting the underlying TaskLoop.

As a follow-up: we really need to synchronize access to base::Thread::delegate_, but @domfarolino doesn't have time to do this before landing this PR because I'm boarding a plane in a second and need to rebase the local mage branch off of the master branch with these change included.

Fixes #41. Fixes #42.