### PR TITLE
Add project-wide build configuration in .bazelrc file

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,3 @@
+build --cxxopt="-std=c++17"
+# For now the default is debug builds
+build --copt="-g" --strip=never --spawn_strategy=standalone

--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ also work on Linux.
 Alternatively you can build any of the examples in
 [`//examples`](https://github.com/domfarolino/browser/tree/master/examples) with
 `bazel build examples/<example_name_here>`.
+
+Project-wide build configuration is in `//.bazelrc` file.


### PR DESCRIPTION
This PR adds a top-level `//.bazelrc` file which for now just contains project-wide build flags like ensuring we build with C++17 and with debugging symbols by default.