### PR TITLE
Introduce base::Bind and base::OnceClosure

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -53,6 +53,7 @@ cc_test(
   name = "base_tests",
   srcs = [
     "build_config_test.cc",
+    "callback_test.cc",
     "scheduling/task_loop_test.cc",
     "threading/simple_thread_test.cc",
     "threading/thread_checker_test.cc",

--- a/base/callback.h
+++ b/base/callback.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <tuple>
 
-// #include "base/check.h"
+#include "base/check.h"
 
 // The code in this file is inspired from Chromium's //base implementation [1],
 // countless Stack Overflow articles that helped me (Dom Farolino) understand
@@ -134,8 +134,7 @@ class OnceClosure {
   }
 
   void operator()() {
-    // TODO(domfarolino): Make this into a CHECK.
-    assert(bind_state_);
+    CHECK(bind_state_);
     bind_state_->Invoke();
     bind_state_.reset();
   }

--- a/base/callback.h
+++ b/base/callback.h
@@ -1,6 +1,8 @@
 #ifndef BASE_CALLBACK_H_
 #define BASE_CALLBACK_H_
 
+#include <assert.h>
+
 #include <functional>
 #include <memory>
 #include <tuple>

--- a/base/callback.h
+++ b/base/callback.h
@@ -157,12 +157,13 @@ OnceClosure BindOnce(Functor&& f, Args&&... args) {
   //     originally-passed-in object is *moved* into the instance of the demoted
   //     type that is stored in, you guessed it, `BindState::args_`. That is if
   //     you pass in std::move(foo) as an argument to `BindOnce()`, the type
-  //     will be decayed from `Foo&&` to `Foo&`, and `BindState::args_` will
-  //     look like `std::tuple<T1, ..., Foo, ...>`. But we perfectly forward all
-  //     of the arguments from this method into `BindState::ctor()`. That way
-  //     when we construct the tuple over there, we construct an object of type
-  //     `Foo` from an object of type `Foo&&`, and therefore *move* the
-  //     originally-passed-in object into an instance stored in the tuple.
+  //     of the argument in `BindState::args_` tuple will be decayed from
+  //     `Foo&&` to `Foo`, and `BindState::args_` will look like
+  //     `std::tuple<T1, ..., Foo, ...>`. But we perfectly forward all of the
+  //     arguments from this method into `BindState::ctor()`. That way when we
+  //     construct the tuple over there, we construct an object of type `Foo`
+  //     from an object of type `Foo&&`, which *moves* the originally-passed-in
+  //     object into an instance stored in the tuple.
   //
   // In order to pass in an lvalue reference and have it be treated as an actual
   // reference at invocation time (thus modifying the value that was originally

--- a/base/callback.h
+++ b/base/callback.h
@@ -2,6 +2,7 @@
 #define BASE_CALLBACK_H_
 
 #include <functional>
+#include <memory>
 #include <tuple>
 
 // Sources:
@@ -9,6 +10,81 @@
 //   - https://stackoverflow.com/questions/66501654
 
 namespace base {
+
+// `BindStateBase` only exists for type erasure -- that is, to allow `Closure`
+// to hold onto a `BindState` while being blind to its bound return type and
+// argument types.
+class BindStateBase {
+ public:
+  BindStateBase() = default;
+  virtual ~BindStateBase() = default;
+  virtual void Invoke() = 0;
+};
+
+template <typename Functor, typename... Args>
+class BindState final : public BindStateBase {
+ public:
+  BindState() = delete;
+  BindState(Functor&& f, Args&&... args) :
+    f_(std::forward<Functor>(f)), args_(std::forward<Args>(args)...) {}
+  BindState(const BindState& other) = delete;
+  BindState& operator=(const BindState& other) = delete;
+  BindState(BindState&& other) = default;
+  BindState& operator=(BindState&& other) = default;
+
+  void Invoke() override {
+    auto seq =
+      std::make_index_sequence<std::tuple_size<decltype(args_)>::value>{};
+    InvokeImpl(std::move(f_), std::move(args_), seq);
+  }
+
+  template <typename BoundFunctor, typename BoundArgs, size_t... Is>
+  void InvokeImpl(BoundFunctor&& f, BoundArgs&& args, std::index_sequence<Is...>) {
+    // TODO(domfarolino): Figure out why this doesn't actually *move* from `args_`.
+    std::forward<BoundFunctor>(f)(std::get<Is>(std::forward<BoundArgs>(args)) ...);
+  }
+
+ private:
+  Functor f_;
+  std::tuple<Args...> args_;
+};
+
+// The `Closure` class is just a light wrapper around `BindStateBase`. Once we
+// introduce `Callback`, `Closure` will be a specialization of `Callback`, and
+// `Callback` will support partially-bound functors.
+class Closure {
+ public:
+  explicit Closure(std::unique_ptr<BindStateBase> bind_state) :
+      bind_state_(std::move(bind_state)) {}
+  Closure(const Closure& other) = delete;
+  Closure& operator=(const Closure& other) = delete;
+  Closure(Closure&& other) = default;
+  Closure& operator=(Closure&& other) = default;
+
+  // TODO(domfarolino): This is kind of weird, it basically eliminates the need
+  // for explicit BindOnce().
+  template <typename Functor, typename... Args>
+  Closure(Functor&& f, Args&&... args) :
+      bind_state_(std::make_unique<BindState<Functor, Args...>>(
+                      std::forward<Functor>(f), std::forward<Args>(args)...)) {}
+
+  void operator()() {
+    // TODO(domfarolino): Make this into a CHECK.
+    assert(bind_state_);
+    bind_state_->Invoke();
+  }
+
+ private:
+  std::unique_ptr<BindStateBase> bind_state_;
+};
+
+template <typename Functor, typename... Args>
+Closure BindOnce(Functor&& f, Args&&... args) {
+  std::unique_ptr<BindStateBase> bind_state =
+      std::make_unique<BindState<Functor, Args...>>(
+          std::forward<Functor>(f), std::forward<Args>(args)...);
+  return Closure(std::move(bind_state));
+}
 
 using Callback = std::function<void()>;
 using Predicate = std::function<bool()>;

--- a/base/callback.h
+++ b/base/callback.h
@@ -128,8 +128,7 @@ class OnceClosure {
           typename = typename std::enable_if_t<
               !std::is_same_v<std::decay_t<Lambda>, OnceClosure>>>
   OnceClosure(Lambda&& lambda) :
-      OnceClosure(BindOnce(std::forward<Lambda>(lambda))) {
-  }
+      OnceClosure(BindOnce(std::forward<Lambda>(lambda))) {}
 
   void operator()() {
     CHECK(bind_state_);

--- a/base/callback.h
+++ b/base/callback.h
@@ -1,8 +1,6 @@
 #ifndef BASE_CALLBACK_H_
 #define BASE_CALLBACK_H_
 
-#include <assert.h>
-
 #include <functional>
 #include <memory>
 #include <tuple>

--- a/base/callback_test.cc
+++ b/base/callback_test.cc
@@ -1,0 +1,230 @@
+#include "base/callback.h"
+
+#include <memory>
+
+#include "gtest/gtest.h"
+
+namespace base {
+
+void AcceptCopyable(int n) {}
+void IncrementReference(int& n) { n++; }
+void AcceptMoveOnly(std::unique_ptr<int>) {}
+
+TEST(Closure, Copyable) {
+  int n = 1;
+  Closure closure = BindOnce(AcceptCopyable, n);
+}
+
+TEST(Closure, IncrementReference) {
+  int n = 1;
+  Closure closure = BindOnce(IncrementReference, n);
+  closure();
+  EXPECT_EQ(n, 2);
+}
+
+TEST(Closure, MoveOnly) {
+  Closure closure = BindOnce(AcceptMoveOnly, std::make_unique<int>(1));
+}
+
+//////////////////////
+
+TEST(Lambda, LambdaBindVariable) {
+  bool executed = false;
+  std::function<void()> closure = std::bind([](bool& executed){
+    executed = true;
+  }, std::ref(executed));
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+TEST(Closure, LambdaBindVariable) {
+  bool executed = false;
+  Closure closure = BindOnce([](bool& executed){
+    executed = true;
+    // This documents a behavior difference from std::bind, note that we don't
+    // have to use std::ref(executed) below, because BindOnce() does not copy
+    // arguments that are to be passed by reference to the given lambda.
+  }, executed);
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+
+TEST(Lambda, LambdaReferenceCapture) {
+  bool executed = false;
+  std::function<void()> closure = [&](){
+    executed = true;
+  };
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+TEST(Closure, LambdaReferenceCapture) {
+  bool executed = false;
+  Closure closure = [&](){
+    executed = true;
+  };
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+TEST(Closure, LambdaReferenceCapture_WithBind) {
+  bool executed = false;
+  Closure closure = BindOnce([&](){
+    executed = true;
+  });
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+
+TEST(Lambda, LambdaCaptureVariableReference) {
+  bool executed = false;
+  std::function<void()> closure = [&executed](){
+    executed = true;
+  };
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+TEST(Closure, LambdaCaptureVariableReference) {
+  bool executed = false;
+  Closure closure = [&executed](){
+    executed = true;
+  };
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+TEST(Closure, LambdaCaptureVariableReference_WithBind) {
+  bool executed = false;
+  Closure closure = BindOnce([&executed](){
+    executed = true;
+  });
+
+  closure();
+  EXPECT_TRUE(executed);
+}
+
+//////////////////////
+
+TEST(Closure, MovedClosureCannotBeCalled) {
+  bool executed = false;
+  Closure closure = [&executed](){
+    executed = true;
+  };
+
+  Closure destination_closure = std::move(closure);
+  EXPECT_FALSE(executed);
+  destination_closure();
+  EXPECT_TRUE(executed);
+
+  ASSERT_DEATH({ closure(); }, "bind_state_");
+}
+
+class CopyableAndMovable {
+ public:
+  CopyableAndMovable() = default;
+  CopyableAndMovable(const CopyableAndMovable& other) {
+    CopyableAndMovable::copy_ctor_called++;
+  }
+  CopyableAndMovable& operator=(const CopyableAndMovable& other) {
+    CopyableAndMovable::copy_ctor_called++;
+    return *this;
+  }
+
+  CopyableAndMovable(CopyableAndMovable&& other) {
+    CopyableAndMovable::move_ctor_called++;
+  }
+  CopyableAndMovable& operator=(CopyableAndMovable&& other) {
+    CopyableAndMovable::move_ctor_called++;
+    return *this;
+  }
+
+  static int copy_ctor_called;
+  static int move_ctor_called;
+};
+
+int CopyableAndMovable::copy_ctor_called = 0;
+int CopyableAndMovable::move_ctor_called = 0;
+
+void AcceptCopyableAndMovableByValue(CopyableAndMovable obj) {}
+void AcceptCopyableAndMovableByReference(CopyableAndMovable& obj) {}
+
+TEST(Closure, AcceptCopyableAndMovableByValue_PassedByValue) {
+  CopyableAndMovable obj;
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 0);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+
+  Closure closure = BindOnce(AcceptCopyableAndMovableByValue, obj);
+
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 1);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+  closure();
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 2);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+  closure();
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 3);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+
+  // Reset counters:
+  CopyableAndMovable::copy_ctor_called = 0;
+  CopyableAndMovable::move_ctor_called = 0;
+}
+
+TEST(Closure, AcceptCopyableAndMovableByValue_PassedByReference) {
+  CopyableAndMovable obj;
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 0);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+
+  Closure closure = BindOnce(AcceptCopyableAndMovableByValue, std::ref(obj));
+
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 1);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+  closure();
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 2);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+  closure();
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 3);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+
+  // Reset counters:
+  CopyableAndMovable::copy_ctor_called = 0;
+  CopyableAndMovable::move_ctor_called = 0;
+}
+
+// TODO(domfarolino): This should fail to compile.
+TEST(Closure, AcceptCopyableAndMovableByReference_PassedByValue) {
+  CopyableAndMovable obj;
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 0);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+
+  Closure closure = BindOnce(AcceptCopyableAndMovableByReference, obj);
+
+  // Reset counters:
+  CopyableAndMovable::copy_ctor_called = 0;
+  CopyableAndMovable::move_ctor_called = 0;
+}
+
+TEST(Closure, AcceptCopyableAndMovableByReference_PassedByReference) {
+  CopyableAndMovable obj;
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 0);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+
+  Closure closure = BindOnce(AcceptCopyableAndMovableByReference, std::ref(obj));
+
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 0);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+  closure();
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 1);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+  closure();
+  EXPECT_EQ(CopyableAndMovable::copy_ctor_called, 2);
+  EXPECT_EQ(CopyableAndMovable::move_ctor_called, 0);
+
+  // Reset counters:
+  CopyableAndMovable::copy_ctor_called = 0;
+  CopyableAndMovable::move_ctor_called = 0;
+}
+
+}; // namespace base

--- a/base/check.h
+++ b/base/check.h
@@ -3,9 +3,6 @@
 
 #include <assert.h>
 
-#include "base/scheduling/scheduling_handles.h"
-#include "base/threading/thread.h"
-
 namespace base {
 
 #define CHECK(condition) assert(condition)
@@ -13,22 +10,6 @@ namespace base {
 #define CHECK_GE(actual, expected) CHECK(actual >= expected)
 #define CHECK_LT(actual, expected) CHECK(actual < expected)
 #define NOTREACHED() CHECK(false)
-
-// Threading and scheduling.
-#define CHECK_ON_THREAD(thread_type) \
-switch (thread_type) { \
-  case ThreadType::UI: \
-    CHECK(base::GetCurrentThreadTaskLoop()); \
-    CHECK_EQ(base::GetUIThreadTaskLoop(), base::GetCurrentThreadTaskLoop()); \
-    break; \
-  case ThreadType::IO: \
-    CHECK(base::GetCurrentThreadTaskLoop()); \
-    CHECK_EQ(base::GetIOThreadTaskLoop(), base::GetCurrentThreadTaskLoop()); \
-    break; \
-  case ThreadType::WORKER: \
-    NOTREACHED(); \
-    break; \
-}
 
 } // namespace base
 

--- a/base/scheduling/scheduling_handles_test.cc
+++ b/base/scheduling/scheduling_handles_test.cc
@@ -120,12 +120,12 @@ TEST_F(SchedulingHandlesTest, MainThreadUIandIOHandlesWork) {
   EXPECT_TRUE(GetCurrentThreadTaskRunner());
 
   GetCurrentThreadTaskRunner()->PostTask(
-    std::bind(&SchedulingHandlesTest::RunOnUIThread, this)
+    BindOnce(&SchedulingHandlesTest::RunOnUIThread, this)
   );
   ui_task_loop->RunUntilIdle();
 
   GetIOThreadTaskLoop()->GetTaskRunner()->PostTask(
-    std::bind(&SchedulingHandlesTest::RunOnIOThread, this)
+    BindOnce(&SchedulingHandlesTest::RunOnIOThread, this)
   );
   ui_task_loop->Run(); // The above will automatically quit the loop.
 }

--- a/base/scheduling/scheduling_handles_test.cc
+++ b/base/scheduling/scheduling_handles_test.cc
@@ -2,6 +2,7 @@
 #include "base/scheduling/scheduling_handles.h"
 #include "base/scheduling/task_loop.h"
 #include "base/threading/simple_thread.h"
+#include "base/threading/thread_checker.h"
 #include "gtest/gtest.h"
 
 // These tests assert that the TaskRunner and TaskLoop handles provided in

--- a/base/scheduling/task_loop.cc
+++ b/base/scheduling/task_loop.cc
@@ -73,8 +73,8 @@ void TaskLoop::RunUntilIdle() {
   Run();
 }
 
-Callback TaskLoop::QuitClosure() {
-  return std::bind(&TaskLoop::Quit, this);
+OnceClosure TaskLoop::QuitClosure() {
+  return BindOnce(&TaskLoop::Quit, this);
 }
 
 }; // namespace base

--- a/base/scheduling/task_loop.h
+++ b/base/scheduling/task_loop.h
@@ -79,6 +79,8 @@ class TaskLoop : public Thread::Delegate,
   // waiting indefinitely.
   void RunUntilIdle();
 
+  // TODO(domfarolino): This should return a `RepeatingClosure` once something
+  // like that exists.
   virtual OnceClosure QuitClosure();
 
  protected:

--- a/base/scheduling/task_loop.h
+++ b/base/scheduling/task_loop.h
@@ -71,7 +71,7 @@ class TaskLoop : public Thread::Delegate,
 
   // TaskRunner::Delegate implementation.
   // Can be called from any thread.
-  void PostTask(Callback cb) override = 0;
+  void PostTask(OnceClosure cb) override = 0;
 
   // Called on the thread that |this| is bound to. Just like |Run()|, except it
   // runs the loop until the underlying event queue is empty or until a task
@@ -79,10 +79,10 @@ class TaskLoop : public Thread::Delegate,
   // waiting indefinitely.
   void RunUntilIdle();
 
-  virtual Callback QuitClosure();
+  virtual OnceClosure QuitClosure();
 
  protected:
-  void ExecuteTask(Callback cb) {
+  void ExecuteTask(OnceClosure cb) {
     cb();
   }
 
@@ -109,7 +109,7 @@ class TaskLoop : public Thread::Delegate,
   // Used to lock |queue_|, since it can be accessed from multiple threads via
   // |PostTask()|.
   base::Mutex mutex_;
-  std::queue<Callback> queue_;
+  std::queue<OnceClosure> queue_;
   bool quit_ = false;
   bool quit_when_idle_ = false;
 

--- a/base/scheduling/task_loop_for_io_mac.cc
+++ b/base/scheduling/task_loop_for_io_mac.cc
@@ -109,7 +109,7 @@ void TaskLoopForIOMac::Run() {
         }
 
         CHECK(queue_.size());
-        Callback cb = std::move(queue_.front());
+        OnceClosure cb = std::move(queue_.front());
         queue_.pop();
         mutex_.unlock();
 
@@ -188,7 +188,7 @@ void TaskLoopForIOMac::UnwatchSocket(SocketReader* socket_reader) {
   mutex_.unlock();
 }
 
-void TaskLoopForIOMac::PostTask(Callback cb) {
+void TaskLoopForIOMac::PostTask(OnceClosure cb) {
   mutex_.lock();
   queue_.push(std::move(cb));
   mutex_.unlock();

--- a/base/scheduling/task_loop_for_io_mac.h
+++ b/base/scheduling/task_loop_for_io_mac.h
@@ -50,7 +50,7 @@ class TaskLoopForIOMac : public TaskLoop {
 
   // TaskRunner::Delegate implementation.
   // Can be called from any thread.
-  void PostTask(Callback cb) override;
+  void PostTask(OnceClosure cb) override;
 
   void QuitWhenIdle() override;
 

--- a/base/scheduling/task_loop_for_io_test.cc
+++ b/base/scheduling/task_loop_for_io_test.cc
@@ -109,7 +109,7 @@ class TestSocketReader : public base::TaskLoopForIO::SocketReader {
 // thread, and be notified on the main thread (via |callback|) when the write is
 // complete.
 void WriteMessagesAndInvokeCallback(int fd, std::vector<std::string> messages,
-                                    Callback callback) {
+                                    OnceClosure callback) {
   for (const std::string& message : messages) {
     write(fd, message.data(), message.size());
   }

--- a/base/scheduling/task_loop_for_io_test.cc
+++ b/base/scheduling/task_loop_for_io_test.cc
@@ -8,7 +8,7 @@
 #include <vector>
 
 #include "base/callback.h"
-#include "base/check.h"
+#include "base/scheduling/scheduling_handles.h"
 #include "base/scheduling/task_loop_for_io.h"
 #include "base/threading/simple_thread.h"
 #include "gtest/gtest.h"

--- a/base/scheduling/task_loop_for_worker.cc
+++ b/base/scheduling/task_loop_for_worker.cc
@@ -17,7 +17,7 @@ void TaskLoopForWorker::Run() {
     }
 
     CHECK(queue_.size());
-    Callback cb = std::move(queue_.front());
+    OnceClosure cb = std::move(queue_.front());
     queue_.pop();
     cv_.release_lock();
 
@@ -30,7 +30,7 @@ void TaskLoopForWorker::Run() {
   quit_when_idle_ = false;
 }
 
-void TaskLoopForWorker::PostTask(Callback cb) {
+void TaskLoopForWorker::PostTask(OnceClosure cb) {
   mutex_.lock();
   queue_.push(std::move(cb));
   mutex_.unlock();

--- a/base/scheduling/task_loop_for_worker.h
+++ b/base/scheduling/task_loop_for_worker.h
@@ -26,7 +26,7 @@ public:
 
   // TaskRunner::Delegate implementation.
   // Can be called from any thread.
-  void PostTask(Callback cb) override;
+  void PostTask(OnceClosure cb) override;
 
   void QuitWhenIdle() override;
 

--- a/base/scheduling/task_loop_test.cc
+++ b/base/scheduling/task_loop_test.cc
@@ -59,7 +59,7 @@ TEST_P(TaskLoopTest, PostTasksBeforeRun) {
   task_loop->PostTask([&](){
     first_task_ran = true;
   });
-  task_loop->PostTask(std::bind([](Callback quit_closure){
+  task_loop->PostTask(BindOnce([](OnceClosure quit_closure){
     quit_closure();
   }, task_loop->QuitClosure()));
 
@@ -69,7 +69,7 @@ TEST_P(TaskLoopTest, PostTasksBeforeRun) {
 
 TEST_P(TaskLoopTest, RunQuitRunQuit) {
   bool first_task_ran = false;
-  task_loop->PostTask(std::bind([&](Callback quit_closure){
+  task_loop->PostTask(BindOnce([&](OnceClosure quit_closure){
     first_task_ran = true;
     quit_closure();
   }, task_loop->QuitClosure()));
@@ -78,7 +78,7 @@ TEST_P(TaskLoopTest, RunQuitRunQuit) {
   EXPECT_EQ(first_task_ran, true);
 
   bool second_task_ran = false;
-  task_loop->PostTask(std::bind([&](Callback quit_closure){
+  task_loop->PostTask(BindOnce([&](OnceClosure quit_closure){
     second_task_ran = true;
     quit_closure();
   }, task_loop->QuitClosure()));
@@ -107,7 +107,7 @@ TEST_P(TaskLoopTest, NestedTasks) {
 TEST_P(TaskLoopTest, GetCurrentThreadTaskRunner) {
   bool first_task_ran = false;
   base::GetCurrentThreadTaskRunner()->PostTask(
-    std::bind([&](Callback quit_closure){
+    BindOnce([&](OnceClosure quit_closure){
       first_task_ran = true;
       quit_closure();
     }, task_loop->QuitClosure()));
@@ -201,7 +201,7 @@ TEST_P(TaskLoopTest, RunUntilIdleMultipleTasks) {
 TEST_P(TaskLoopTest, RunUntilIdleEarlyQuit) {
   bool first_task_ran = false;
   task_loop->PostTask(
-    std::bind([&](Callback quit_closure){
+    BindOnce([&](OnceClosure quit_closure){
       first_task_ran = true;
       quit_closure();
     }, task_loop->QuitClosure()));

--- a/base/scheduling/task_runner.h
+++ b/base/scheduling/task_runner.h
@@ -30,13 +30,13 @@ class TaskRunner final {
   // want.
   class Delegate {
    public:
-    virtual void PostTask(Callback cb) = 0;
+    virtual void PostTask(OnceClosure cb) = 0;
   };
 
   TaskRunner(std::weak_ptr<Delegate> weak_delegate) :
     weak_delegate_(weak_delegate) {}
 
-  void PostTask(Callback cb) {
+  void PostTask(OnceClosure cb) {
     if (auto delegate = weak_delegate_.lock()) {
       delegate->PostTask(std::move(cb));
       return;

--- a/base/threading/simple_thread.h
+++ b/base/threading/simple_thread.h
@@ -16,25 +16,28 @@ class SimpleThread : public Thread {
 public:
   class SimpleThreadDelegate : public Thread::Delegate {
    public:
-    explicit SimpleThreadDelegate(OnceClosure f) : f_(std::move(f)) {}
+    explicit SimpleThreadDelegate(OnceClosure thread_function) :
+        thread_function_(std::move(thread_function)) {}
 
     // Thread::Delegate implementation.
     void BindToCurrentThread(ThreadType) override {}
     void Run() override {
-      f_();
+      CHECK(thread_function_);
+      thread_function_();
     }
     std::shared_ptr<TaskRunner> GetTaskRunner() override { NOTREACHED(); }
     void Quit() override {}
     void QuitWhenIdle() override {}
 
    private:
-    OnceClosure f_;
+    OnceClosure thread_function_;
   };
 
-  template <typename F, typename... Ts>
-  SimpleThread(F func, Ts... args) : Thread() {
-    OnceClosure f = BindOnce(std::forward<F>(func), std::forward<Ts>(args)...);
-    delegate_.reset(new SimpleThreadDelegate(std::move(f)));
+  template <typename F, typename... Args>
+  SimpleThread(F func, Args... args) : Thread() {
+    OnceClosure thread_function =
+        BindOnce(std::forward<F>(func), std::forward<Args>(args)...);
+    delegate_.reset(new SimpleThreadDelegate(std::move(thread_function)));
 
     // Start the thread with the overridden delegate.
     Start();

--- a/base/threading/simple_thread_test.cc
+++ b/base/threading/simple_thread_test.cc
@@ -8,7 +8,7 @@ void OffMainThread(bool& thread_ran) {
   thread_ran = true;
 }
 
-void OffMainThreadRunCallback(Callback callback) {
+void OffMainThreadRunCallback(OnceClosure callback) {
   callback();
 }
 
@@ -19,12 +19,15 @@ TEST(SimpleThreadTest, BasicPassByReference) {
   EXPECT_EQ(thread_ran, true);
 }
 
+/*
+Note that this will not compile because [..]
 TEST(SimpleThreadTest, BasicPassByValue) {
   bool thread_ran = false;
   SimpleThread thread(OffMainThread, thread_ran);
   thread.join();
   EXPECT_EQ(thread_ran, false);
 }
+*/
 
 TEST(SimpleThreadTest, BasicWithLambdaReferenceCapture) {
   bool thread_ran = false;
@@ -46,7 +49,7 @@ TEST(SimpleThreadTest, BasicWithLambdaCallback) {
 
 TEST(SimpleThreadTest, BasicWithLambdaAndLambdaParameterPassed) {
   bool thread_ran = false;
-  SimpleThread thread([](Callback callback){
+  SimpleThread thread([](OnceClosure callback){
     callback();
   }, [&](){
     thread_ran = true;

--- a/base/threading/simple_thread_test.cc
+++ b/base/threading/simple_thread_test.cc
@@ -19,16 +19,6 @@ TEST(SimpleThreadTest, BasicPassByReference) {
   EXPECT_EQ(thread_ran, true);
 }
 
-/*
-Note that this will not compile because [..]
-TEST(SimpleThreadTest, BasicPassByValue) {
-  bool thread_ran = false;
-  SimpleThread thread(OffMainThread, thread_ran);
-  thread.join();
-  EXPECT_EQ(thread_ran, false);
-}
-*/
-
 TEST(SimpleThreadTest, BasicWithLambdaReferenceCapture) {
   bool thread_ran = false;
   SimpleThread thread([&](){

--- a/base/threading/thread.cc
+++ b/base/threading/thread.cc
@@ -101,7 +101,7 @@ void Thread::join() {
   started_via_api_ = false;
 }
 
-void Thread::RegisterDelegateResetCallbackForTesting(Callback cb) {
+void Thread::RegisterDelegateResetCallbackForTesting(OnceClosure cb) {
   delegate_reset_callback_for_testing_ = std::move(cb);
 }
 

--- a/base/threading/thread.h
+++ b/base/threading/thread.h
@@ -59,7 +59,7 @@ class Thread {
   static void sleep_for(std::chrono::milliseconds ms);
   void join();
 
-  void RegisterDelegateResetCallbackForTesting(Callback cb);
+  void RegisterDelegateResetCallbackForTesting(OnceClosure cb);
 
  protected:
   // These methods run on the newly-created thread.
@@ -98,7 +98,7 @@ class Thread {
   // we require a call to Stop()/join() before calling Start() again.
   bool started_via_api_ = false;
 
-  Callback delegate_reset_callback_for_testing_;
+  OnceClosure delegate_reset_callback_for_testing_;
 };
 
 } // namespace base

--- a/base/threading/thread_checker.h
+++ b/base/threading/thread_checker.h
@@ -3,7 +3,34 @@
 
 #include <memory>
 
+#include "base/scheduling/scheduling_handles.h"
+
 namespace base {
+
+// This is a light-weight macro that can be used to assert the current thread
+// type, as opposed to the heavier `ThreadChecker` class below which is
+// typically used as a member function in classes that want to regularly assert
+// that the thread their methods are being invoked on is the same thread that
+// the object was constructed on.
+//
+// `ThreadChecker` can be used to check that a given object is used on the
+// "correct" thread regardless of thread type, where "correct" is defined as the
+// thread that the `ThreadChecker` (and likely the owning object) was
+// constructed on.
+#define CHECK_ON_THREAD(thread_type) \
+switch (thread_type) { \
+  case ThreadType::UI: \
+    CHECK(base::GetCurrentThreadTaskLoop()); \
+    CHECK_EQ(base::GetUIThreadTaskLoop(), base::GetCurrentThreadTaskLoop()); \
+    break; \
+  case ThreadType::IO: \
+    CHECK(base::GetCurrentThreadTaskLoop()); \
+    CHECK_EQ(base::GetIOThreadTaskLoop(), base::GetCurrentThreadTaskLoop()); \
+    break; \
+  case ThreadType::WORKER: \
+    NOTREACHED(); \
+    break; \
+}
 
 class TaskLoop;
 

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -15,3 +15,8 @@ cc_binary(
   srcs = ["task_posting.cc"],
   deps = ["//base:base"],
 )
+cc_binary(
+  name = "bind",
+  srcs = ["bind.cc"],
+  deps = ["//base:base"],
+)

--- a/examples/bind.cc
+++ b/examples/bind.cc
@@ -1,0 +1,11 @@
+#include <iostream>
+
+#include "base/callback.h"
+
+int main() {
+  base::OnceClosure closure = [](){
+    std::cout << "OnceClosure() is being invoked()" << std::endl;
+  };
+  closure();
+  return 0;
+}

--- a/examples/bind.cc
+++ b/examples/bind.cc
@@ -2,16 +2,18 @@
 
 #include "base/callback.h"
 
-void FunctionA(int n) {
-  std::cout << "FunctionA called with n = " << n << std::endl;
-}
-
-void FunctionB(base::OnceClosure cb) {
-  cb();
+void IncrementInteger(int& n) {
+  n++;
 }
 
 int main() {
-  base::OnceClosure closure = base::BindOnce(FunctionA, 101);
-  FunctionB(std::move(closure));
+  int n = 0;
+  base::OnceClosure cb1 = base::BindOnce(IncrementInteger, std::ref(n));
+  cb1();
+  std::cout << n << std::endl;
+
+  base::OnceClosure cb2 = [&n](){n++;};
+  cb2();
+  std::cout << n << std::endl;
   return 0;
 }

--- a/examples/bind.cc
+++ b/examples/bind.cc
@@ -2,10 +2,16 @@
 
 #include "base/callback.h"
 
+void FunctionA(int n) {
+  std::cout << "FunctionA called with n = " << n << std::endl;
+}
+
+void FunctionB(base::OnceClosure cb) {
+  cb();
+}
+
 int main() {
-  base::OnceClosure closure = [](){
-    std::cout << "OnceClosure() is being invoked()" << std::endl;
-  };
-  closure();
+  base::OnceClosure closure = base::BindOnce(FunctionA, 101);
+  FunctionB(std::move(closure));
   return 0;
 }

--- a/examples/run_loop.cc
+++ b/examples/run_loop.cc
@@ -8,32 +8,33 @@
 // This runs on a worker thread, and posts tasks back to the main thread.
 void PostTasksBackToMainThread(
     std::shared_ptr<base::TaskRunner> main_thread_task_runner) {
+  std::cout << "START" << std::endl;
   for (int i = 0; i < 5; ++i) {
-    main_thread_task_runner->PostTask(std::bind([](){
+    main_thread_task_runner->PostTask([](){
       std::cout << "Main thread: Getting a ping from the worker thread" << std::endl;
-    }));
+    });
     base::Thread::sleep_for(std::chrono::milliseconds(500));
   }
 
-  main_thread_task_runner->PostTask(std::bind([](){
+  main_thread_task_runner->PostTask([](){
     std::cout << "Main thread: Getting the final ping from the worker "
                  "thread" << std::endl;
     // Since this is run on the main thread, this will quit the main thread's
     // TaskLoop.
     base::GetCurrentThreadTaskLoop()->Quit();
-  }));
+  });
 }
 
 int main() {
   std::shared_ptr<base::TaskLoop> main_loop =
-    base::TaskLoop::Create(base::ThreadType::UI);
+      base::TaskLoop::Create(base::ThreadType::UI);
 
   // Spin up a worker thread that will perform some work and post tasks to the
   // main thread while we're waiting for the worker thread to finish. Just as an
   // example, we'll block the main thread until the work is done, solely by
   // running our loop and asynchronously waiting for its result.
   base::SimpleThread simple(
-    std::bind(&PostTasksBackToMainThread, main_loop->GetTaskRunner()));
+      PostTasksBackToMainThread, main_loop->GetTaskRunner());
   main_loop->Run();
 
   simple.join();

--- a/examples/task_posting.cc
+++ b/examples/task_posting.cc
@@ -46,18 +46,18 @@ void PostTasksToWorkerThread(base::Thread& thread) {
       break;
 
     if (task_number == 1) {
-      task_runner->PostTask(std::bind(&TaskOne));
+      task_runner->PostTask(base::BindOnce(&TaskOne));
     } else if (task_number == 2) {
       int input;
       std::cout << "Enter TaskTwo's input: ";
       std::cin >> input;
-      task_runner->PostTask(std::bind(&TaskTwo, input));
+      task_runner->PostTask(base::BindOnce(&TaskTwo, input));
     } else {
       int input;
       std::cout << "Enter TaskThree's input: ";
       std::cin >> input;
       TaskParam param(input);
-      auto task  = std::bind(&TaskThree, param);
+      base::OnceClosure task  = base::BindOnce(&TaskThree, param);
       task_runner->PostTask(std::move(task));
     }
   }


### PR DESCRIPTION
This PR introduces base::Bind, which is an alternative to std::bind that produces base::OnceClosure objects that support move-only bound parameters 🎉. This is required for the mage PR https://github.com/domfarolino/browser/pull/32 since that is the first instance where we need to post a task which binds a method with move-only parameters.

This is heavily inspired by the Chromium implementation as the code documentation suggests, and has taught me a ton about some interesting C++ language features. A huge shout-out goes to @zetafunction, a Chromium //base OWNER familiar with bind internals and many C++ things that he helped walk me through.

(PR is nearly finished, but still in progress).

Fixes https://github.com/domfarolino/browser/issues/16.