### PR TITLE
[#36] Update GTest version and hash

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,7 +2,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
   name = "gtest",
-  url = "https://github.com/google/googletest/archive/release-1.10.0.zip",
-  sha256 = "94c634d499558a76fa649edb13721dce6e98fb1e7018dfaeba3cd7a083945e91",
-  strip_prefix = "googletest-release-1.10.0",
+  url = "https://github.com/google/googletest/archive/release-1.11.0.zip",
+  sha256 = "353571c2440176ded91c2de6d6cd88ddd41401d14692ec1f99e35d013feda55a",
+  strip_prefix = "googletest-release-1.11.0",
 )


### PR DESCRIPTION
Closes:  https://github.com/domfarolino/browser/issues/36