### PR TITLE
Fix Linux build

### DIFF
--- a/base/scheduling/task_loop_test.cc
+++ b/base/scheduling/task_loop_test.cc
@@ -24,6 +24,9 @@ class TaskLoopTest : public testing::Test,
       case base::ThreadType::WORKER:
         return "WORKER";
     }
+
+    NOTREACHED();
+    return "NOTREACHED";
   }
 
   TaskLoopTest() : thread_type_(GetParam()) {}

--- a/base/scheduling/task_runner.h
+++ b/base/scheduling/task_runner.h
@@ -1,6 +1,7 @@
 #ifndef BASE_SCHEDULING_TASK_RUNNER_H_
 #define BASE_SCHEDULING_TASK_RUNNER_H_
 
+#include <cstdio>
 #include <memory>
 
 #include "base/callback.h"


### PR DESCRIPTION
The compiler complained about a few things on Linux, and this PR fixes those in preparation for writing the Linux implementation of TaskLoopForIO.