### PR TITLE
Implement TaskLoopForIOLinux

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -31,7 +31,7 @@ cc_library(
   ] +
   select({
     ":mac": ["scheduling/task_loop_for_io_mac.h"],
-    ":linux": [],
+    ":linux": ["scheduling/task_loop_for_io_linux.h"],
   }),
   srcs = [
     "scheduling/scheduling_handles.cc",
@@ -42,7 +42,7 @@ cc_library(
   ] +
   select({
     ":mac": ["scheduling/task_loop_for_io_mac.cc"],
-    ":linux": [],
+    ":linux": ["scheduling/task_loop_for_io_linux.cc"],
   }),
 
   deps = [],
@@ -64,8 +64,10 @@ cc_test(
       "scheduling/task_loop_for_io_test.cc",
       "scheduling/scheduling_handles_test.cc",
     ],
-    # TODO(domfarolino): Enable the task loop for IO tests on linux once an IO task loop is implemented there.
-    ":linux": [],
+    ":linux": [
+      "scheduling/task_loop_for_io_test.cc",
+      "scheduling/scheduling_handles_test.cc",
+    ],
   }),
   copts = ["-Iexternal/gtest/include"],
   deps = [

--- a/base/BUILD
+++ b/base/BUILD
@@ -58,17 +58,9 @@ cc_test(
     "threading/simple_thread_test.cc",
     "threading/thread_checker_test.cc",
     "threading/thread_test.cc",
-  ] +
-  select({
-    ":mac": [
-      "scheduling/task_loop_for_io_test.cc",
-      "scheduling/scheduling_handles_test.cc",
-    ],
-    ":linux": [
-      "scheduling/task_loop_for_io_test.cc",
-      "scheduling/scheduling_handles_test.cc",
-    ],
-  }),
+    "scheduling/task_loop_for_io_test.cc",
+    "scheduling/scheduling_handles_test.cc",
+  ],
   copts = ["-Iexternal/gtest/include"],
   deps = [
     "//base:base",

--- a/base/scheduling/task_loop.cc
+++ b/base/scheduling/task_loop.cc
@@ -7,6 +7,8 @@
 #include "base/scheduling/scheduling_handles.h"
 #if defined(OS_MACOS)
 #include "base/scheduling/task_loop_for_io.h"
+#elif defined(OS_LINUX)
+#include "base/scheduling/task_loop_for_io.h"
 #endif
 #include "base/scheduling/task_loop_for_ui.h"
 #include "base/scheduling/task_loop_for_worker.h"
@@ -44,6 +46,8 @@ std::shared_ptr<TaskLoop> TaskLoop::CreateUnbound(ThreadType type) {
       return std::shared_ptr<TaskLoopForUI>(new TaskLoopForUI());
     case ThreadType::IO:
 #if defined(OS_MACOS)
+      return std::shared_ptr<TaskLoopForIO>(new TaskLoopForIO());
+#elif defined(OS_LINUX)
       return std::shared_ptr<TaskLoopForIO>(new TaskLoopForIO());
 #else
       NOTREACHED();

--- a/base/scheduling/task_loop.cc
+++ b/base/scheduling/task_loop.cc
@@ -5,11 +5,7 @@
 #include "base/build_config.h"
 #include "base/check.h"
 #include "base/scheduling/scheduling_handles.h"
-#if defined(OS_MACOS)
 #include "base/scheduling/task_loop_for_io.h"
-#elif defined(OS_LINUX)
-#include "base/scheduling/task_loop_for_io.h"
-#endif
 #include "base/scheduling/task_loop_for_ui.h"
 #include "base/scheduling/task_loop_for_worker.h"
 
@@ -45,14 +41,7 @@ std::shared_ptr<TaskLoop> TaskLoop::CreateUnbound(ThreadType type) {
     case ThreadType::UI:
       return std::shared_ptr<TaskLoopForUI>(new TaskLoopForUI());
     case ThreadType::IO:
-#if defined(OS_MACOS)
       return std::shared_ptr<TaskLoopForIO>(new TaskLoopForIO());
-#elif defined(OS_LINUX)
-      return std::shared_ptr<TaskLoopForIO>(new TaskLoopForIO());
-#else
-      NOTREACHED();
-      return std::shared_ptr<TaskLoopForWorker>();
-#endif
     case ThreadType::WORKER:
       return std::shared_ptr<TaskLoopForWorker>(new TaskLoopForWorker());
   }

--- a/base/scheduling/task_loop_for_io.h
+++ b/base/scheduling/task_loop_for_io.h
@@ -30,8 +30,8 @@
 
 #if defined(OS_MACOS)
 #include "base/scheduling/task_loop_for_io_mac.h"
-// TODO(domfarolino): Implement an IO task loop for Linux, and maybe even it
-// will be general enough for both platforms.
+#elif defined(OS_LINUX)
+#include "base/scheduling/task_loop_for_io_linux.h"
 #endif
 
 namespace base {
@@ -39,8 +39,7 @@ namespace base {
 #if defined(OS_MACOS)
 using TaskLoopForIO = TaskLoopForIOMac;
 #elif defined(OS_LINUX)
-// using TaskLoopForIO = TaskLoopForIOLinux;
-#error This platform does not support TaskLoopForIO just yet
+using TaskLoopForIO = TaskLoopForIOLinux;
 #endif
 
 } // namespace base

--- a/base/scheduling/task_loop_for_io_linux.cc
+++ b/base/scheduling/task_loop_for_io_linux.cc
@@ -65,7 +65,8 @@ void TaskLoopForIOLinux::Run() {
         int read_rv = read(eventfd_wakeup_, &msg, sizeof(msg));
         CHECK(read_rv != -1);
 
-        // See documentation above this code in `TaskLoopForIOMac`.
+        // See corresponding documentation above this code in
+        // `TaskLoopForIOMac`.
         if (queue_.empty()) {
           mutex_.unlock();
           continue;
@@ -85,13 +86,7 @@ void TaskLoopForIOLinux::Run() {
       }
     }
 
-    // By this point, |mutex_| will always be unlocked so that we can lock it
-    // for the next iteration. Note that we can't just unlock it here at the end
-    // of this loop, to make things simple. We have to unlock it before we
-    // process whatever event type we're processing or else we are prone to
-    // deadlocks. For example, if we keep |mutex_| locked while we run a task
-    // that we pull from the |queue_|, then if that task calls PostTask() on
-    // this loop, then it will try and lock |mutex_| and deadlock forever.
+    // See corresponding documentation at this location in `TaskLoopForIOMac`.
   }  // while (true).
 
   // We need to reset |quit_| when |Run()| actually completes, so that we can

--- a/base/scheduling/task_loop_for_io_linux.cc
+++ b/base/scheduling/task_loop_for_io_linux.cc
@@ -6,7 +6,8 @@
 
 namespace base {
 
-TaskLoopForIOLinux::TaskLoopForIOLinux() : epollfd_(epoll_create1(0)), eventfd_wakeup_(eventfd(0, EFD_SEMAPHORE)) {
+TaskLoopForIOLinux::TaskLoopForIOLinux()
+    : epollfd_(epoll_create1(0)), eventfd_wakeup_(eventfd(0, EFD_SEMAPHORE)) {
   CHECK(epollfd_ != -1);
   CHECK(eventfd_wakeup_ != -1);
 
@@ -89,7 +90,7 @@ void TaskLoopForIOLinux::Run() {
     // deadlocks. For example, if we keep |mutex_| locked while we run a task
     // that we pull from the |queue_|, then if that task calls PostTask() on
     // this loop, then it will try and lock |mutex_| and deadlock forever.
-  } // while (true).
+  }  // while (true).
 
   // We need to reset |quit_| when |Run()| actually completes, so that we can
   // call |Run()| again later.
@@ -170,4 +171,4 @@ void TaskLoopForIOLinux::Wakeup() {
   CHECK(rv != 0);
 }
 
-}; // namespace base
+};  // namespace base

--- a/base/scheduling/task_loop_for_io_linux.cc
+++ b/base/scheduling/task_loop_for_io_linux.cc
@@ -23,6 +23,8 @@ TaskLoopForIOLinux::TaskLoopForIOLinux()
 }
 
 TaskLoopForIOLinux::~TaskLoopForIOLinux() {
+  CHECK(close(eventfd_wakeup_) != -1);
+  CHECK(close(epollfd_) != -1);
   CHECK(async_socket_readers_.empty());
 }
 

--- a/base/scheduling/task_loop_for_io_linux.cc
+++ b/base/scheduling/task_loop_for_io_linux.cc
@@ -1,0 +1,187 @@
+#include "base/scheduling/task_loop_for_io_linux.h"
+
+#include <stdint.h>
+#include <sys/epoll.h>
+#include <sys/errno.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
+
+#include <iostream>
+#include <vector>
+
+namespace base {
+
+TaskLoopForIOLinux::TaskLoopForIOLinux() {
+  epollfd_ = epoll_create1(0);
+  CHECK(epollfd_ != -1);
+
+  // Use `EFD_SEMAPHORE` so that multiple wakeups sent to `eventfd_wakeup_`
+  // (from multiple e.g., PostTask()s, Quit()s, QuitWhenIdle()s) result in the
+  // internal counter for the file descriptor being incremented each time. This
+  // results in `epoll_wait()` always notifying `TaskLoopForIOLinux::Run()` that
+  // there is something that needs to be addressed until we `read()` each
+  // message off of the file descriptor, which decrements the internal counter.
+  //
+  // See https://man7.org/linux/man-pages/man2/eventfd.2.html.
+  eventfd_wakeup_ = eventfd(0, EFD_SEMAPHORE);
+  CHECK(eventfd_wakeup_ != -1);
+  epoll_data_t event_data;
+  event_data.fd = eventfd_wakeup_;
+  struct epoll_event ev;
+  ev.events = EPOLLIN;
+  ev.data = event_data;
+
+  int rv = epoll_ctl(epollfd_, EPOLL_CTL_ADD, eventfd_wakeup_, &ev);
+  CHECK(rv != -1);
+}
+
+TaskLoopForIOLinux::~TaskLoopForIOLinux() {
+  CHECK(async_socket_readers_.empty());
+}
+
+void TaskLoopForIOLinux::Run() {
+  while (true) {
+    struct epoll_event events[MAX_EVENTS];
+    int timeout = quit_when_idle_ ? 0 : -1;
+    int rv = epoll_wait(epollfd_, events, MAX_EVENTS, timeout);
+
+    // We grab a lock so that neither of the following are tampered with on
+    // another thread while we are reading/writing them:
+    //   - |queue_|
+    //   - |async_socket_readers_|
+    mutex_.lock();
+
+    // At this point we have at least one event from the kernel, unless we're in
+    // the |quit_when_idle_| mode and have nothing to do. We detect this
+    // idleness via `rv == 0` later and break.
+    CHECK(rv >= 1 || (quit_when_idle_ && rv == 0));
+
+    // See documentation above this code in `TaskLoopForIOMac`.
+    if (quit_ || (quit_when_idle_ && rv == 0)) {
+      mutex_.unlock();
+      break;
+    }
+
+    CHECK_GE(rv, 1);
+
+    // Process any queued events (the number of which is `rv`).
+    for (int i = 0; i < rv; ++i) {
+      struct epoll_event* event = &events[i];
+      int fd = event->data.fd;
+      if (fd == eventfd_wakeup_) {
+        // Read a message off of `eventfd_wakeup_`, which will decrement the
+        // internal counter of messages on that file descriptor, since it is in
+        // `EFD_SEMAPHORE` mode.
+        uint64_t msg = 0;
+        int read_rv = read(eventfd_wakeup_, &msg, sizeof(msg));
+        CHECK(read_rv != -1);
+
+        // See documentation above this code in `TaskLoopForIOMac`.
+        if (queue_.empty()) {
+          mutex_.unlock();
+          continue;
+        }
+
+        CHECK(queue_.size());
+        OnceClosure cb = std::move(queue_.front());
+        queue_.pop();
+        mutex_.unlock();
+
+        ExecuteTask(std::move(cb));
+      } else {
+        auto* socket_reader = async_socket_readers_[fd];
+        mutex_.unlock();
+        CHECK(socket_reader);
+        socket_reader->OnCanReadFromSocket();
+      }
+    }
+
+    // By this point, |mutex_| will always be unlocked so that we can lock it
+    // for the next iteration. Note that we can't just unlock it here at the end
+    // of this loop, to make things simple. We have to unlock it before we
+    // process whatever event type we're processing or else we are prone to
+    // deadlocks. For example, if we keep |mutex_| locked while we run a task
+    // that we pull from the |queue_|, then if that task calls PostTask() on
+    // this loop, then it will try and lock |mutex_| and deadlock forever.
+  } // while (true).
+
+  // We need to reset |quit_| when |Run()| actually completes, so that we can
+  // call |Run()| again later.
+  quit_ = false;
+  quit_when_idle_ = false;
+}
+
+void TaskLoopForIOLinux::WatchSocket(SocketReader* socket_reader) {
+  CHECK(socket_reader);
+  int fd = socket_reader->Socket();
+
+  epoll_data_t event_data;
+  event_data.fd = fd;
+  struct epoll_event ev;
+  ev.events = EPOLLIN;
+  ev.data = event_data;
+
+  int rv = epoll_ctl(epollfd_, EPOLL_CTL_ADD, fd, &ev);
+  CHECK(rv != -1);
+
+  mutex_.lock();
+  // A socket reader can only be registered once.
+  CHECK_EQ(async_socket_readers_.find(fd), async_socket_readers_.end());
+  async_socket_readers_[fd] = socket_reader;
+  // event_count_++;
+  mutex_.unlock();
+}
+
+void TaskLoopForIOLinux::UnwatchSocket(SocketReader* socket_reader) {
+  CHECK(socket_reader);
+  int fd = socket_reader->Socket();
+
+  epoll_data_t event_data;
+  event_data.fd = fd;
+  struct epoll_event ev;
+  ev.events = EPOLLIN;
+  ev.data = event_data;
+
+  int rv = epoll_ctl(epollfd_, EPOLL_CTL_DEL, fd, &ev);
+  CHECK(rv != -1);
+
+  mutex_.lock();
+  CHECK(!async_socket_readers_.empty());
+  async_socket_readers_.erase(fd);
+  // event_count_--;
+  mutex_.unlock();
+}
+
+void TaskLoopForIOLinux::PostTask(OnceClosure cb) {
+  mutex_.lock();
+  queue_.push(std::move(cb));
+  mutex_.unlock();
+  Wakeup();
+}
+
+void TaskLoopForIOLinux::Quit() {
+  mutex_.lock();
+  quit_ = true;
+  mutex_.unlock();
+  Wakeup();
+}
+
+void TaskLoopForIOLinux::QuitWhenIdle() {
+  mutex_.lock();
+  quit_when_idle_ = true;
+  mutex_.unlock();
+  Wakeup();
+}
+
+void TaskLoopForIOLinux::Wakeup() {
+  // Send an empty message to |eventfd_wakeup_|. See corresponding documentation
+  // in `TaskLoopForIOMac::Wakeup()`.
+  //
+  // The value of what we write doesn't matter since `eventfd_wakeup_` is in
+  // `EFD_SEMAPHORE` mode. See `TaskLoopForIOLinux::ctor()`.
+  uint64_t msg = 1;
+  ssize_t rv = write(eventfd_wakeup_, &msg, sizeof(msg));
+  CHECK(rv != 0);
+}
+
+}; // namespace base

--- a/base/scheduling/task_loop_for_io_linux.cc
+++ b/base/scheduling/task_loop_for_io_linux.cc
@@ -165,7 +165,7 @@ void TaskLoopForIOLinux::Wakeup() {
   // in `TaskLoopForIOMac::Wakeup()`.
   //
   // The value of what we write doesn't matter since `eventfd_wakeup_` is in
-  // `EFD_SEMAPHORE` mode. See `TaskLoopForIOLinux::ctor()`.
+  // `EFD_SEMAPHORE` mode. See documentation above `eventfd_wakeup_`.
   uint64_t msg = 1;
   ssize_t rv = write(eventfd_wakeup_, &msg, sizeof(msg));
   CHECK(rv != 0);

--- a/base/scheduling/task_loop_for_io_linux.h
+++ b/base/scheduling/task_loop_for_io_linux.h
@@ -1,23 +1,15 @@
 #ifndef BASE_SCHEDULING_TASK_LOOP_FOR_IO_LINUX_H_
 #define BASE_SCHEDULING_TASK_LOOP_FOR_IO_LINUX_H_
 
-#include <stdint.h>
-#include <sys/epoll.h>
-#include <sys/errno.h>
-#include <sys/eventfd.h>
-
 #include <map>
-#include <queue>
-#include <vector>
 
-#include "base/callback.h"
 #include "base/scheduling/task_loop.h"
-#include "base/synchronization/mutex.h"
-
-#define MAX_EVENTS 10
 
 namespace base {
 
+// Note that this `TaskLoop` variant only works on Linux, or platforms with
+// `epoll`, as we use `eventfd` and `epoll` to block on OS-level notifications
+// and IPC primitives.
 class TaskLoopForIOLinux : public TaskLoop {
  public:
   // |SocketReader|s register themselves with a |TaskLoopForIO| associated with
@@ -59,19 +51,27 @@ class TaskLoopForIOLinux : public TaskLoop {
   void Wakeup();
 
  private:
-  int epollfd_;
-  int eventfd_wakeup_;
+  // The epoll file descriptor that drives the task loop. This is only written
+  // to once on whatever thread `this` loop is constructed on (note this may be
+  // different than the thread that the loop ultimately gets bound to). Can be
+  // used in `epoll_*()` calls from any thread.
+  const int epollfd_;
 
-  // The kqueue that drives the task loop. This is only written to once on
-  // whatever thread |this| loop is constructed on (note this may be different
-  // than the thread it is ultimately bound to). Can be read from any thread.
-  //const int kqueue_;
-
-  // Receive right to which an empty Mach message is sent to wake up the loop
-  // in response to |PostTask()|.
-  //mach_port_t wakeup_;
-  // Scratch buffer that is used to receive the message sent to |wakeup_|.
-  //mach_msg_empty_rcv_t wakeup_buffer_;
+  // Eventfd file descriptor used by `Wakeup()` to wake up the task loop in
+  // response to `PostTask()`, `Quit()`, `QuitWhenIdle()`.
+  //
+  // It is created with the `EFD_SEMAPHORE` flag so that multiple wakeups (from
+  // many e.g., PostTask()s, Quit()s, QuitWhenIdle()s) result in the internal
+  // counter for the file descriptor being incremented each time. This results
+  // in `epoll_wait()` always notifying `Run()` that there is something that
+  // needs to be addressed, until we `read()` each message off of the file
+  // descriptor, which in turn decrements the internal counter. If we did not
+  // use semaphore semantics, the contents of the `read()` on the file
+  // descriptor would tell us how many notifications `eventfd_wakeup_` has
+  // received, which does not work cleanly with our `Run()` loop implementation.
+  //
+  // See https://man7.org/linux/man-pages/man2/eventfd.2.html.
+  const int eventfd_wakeup_;
 
   // These are listeners that get notified when their file descriptor has been
   // written to and is ready to read from. |SocketReader|s are expected to
@@ -80,49 +80,8 @@ class TaskLoopForIOLinux : public TaskLoop {
   // thread interacting with |this|.
   std::map<int, SocketReader*> async_socket_readers_;
 
-  // NOTE ABOUT THREAD SAFETY:
-  //   * The below |event_count_| can be modified from any thread that interacts
-  //     with |this| loop, and therefore its writes are guarded by |mutex_| so
-  //     that all writes persist.
-  //   * The below |events_| is only ever written to and read from the thread
-  //     that |this| loop is bound to, in the Run() method.
-  //   * Reading from these variables does not need to be synchronized. In
-  //     Run(), we read from |event_count_| to resize |events_|. You can imagine
-  //     that once we read |event_count_| to resize |events_| (for submission to
-  //     `kevent64()`), we're only taking a snapshot of the value. It could have
-  //     changed by the time we _actually_ call `kevent64()` to wait for events,
-  //     to either greater or less than the one we snapshotted. Let's consider
-  //     each case separately.
-  //       1.) Value was increased after snapshot:
-  //           For example, we enter the loop in Run() with |event_count_| set
-  //           to 4 (three socket readers + our wakeup event). We resize
-  //           |events_| accordingly, but before we call `kevent64()` to wait
-  //           for at most 4 events, two more readers are added, and the actual
-  //           value of |event_count_| gets updated to 6 and the underlying
-  //           kernel queue knows about 6 possible event sources. We call
-  //           `kevent64()` with the argument `num_events=4`, meaning we'll
-  //           return with at 4 events ready to process from the 6 event
-  //           sources. This is totally valid! The kqueue system actually lets
-  //           you process a single event at a time with num_events=1 if you
-  //           want, it's just less efficient.
-  //       2.) Value was decreased after snapshot:
-  //           Similar to the above example, we invoke `kevent64()` with
-  //           `num_events=x` even though the number of event sources that the
-  //           underlying kernel queue actually knows about is x-2, for example.
-  //           In this case, the number of events we are willing to accept is
-  //           larger than the number of events the kernel queue will ever
-  //           produce, which is also fine. You can try setting |event_count_|
-  //           to an absurdly high number below and running the tests.
-  // END NOTE
-  // The number of event types (filters) that we're interested in listening to
-  // via |kqueue_|. There is always at least 1, for the |wakeup_| port (or
-  // |port_set_|), but increase this count whenever we register a new e.g.,
-  // |SocketReader|.
+  // See corresponding documentation above `TaskLoopForIOMac::event_count_`.
   size_t event_count_ = 1;
-  // This buffer is where events from the kernel queue are stored after calls to
-  // |kevent64|. This buffer is consulted in |Run()|, where events are pulled
-  // and the loop responds to them.
-  std::vector<struct epoll_event> events_{event_count_};
 };
 
 } // namespace base

--- a/base/scheduling/task_loop_for_io_linux.h
+++ b/base/scheduling/task_loop_for_io_linux.h
@@ -17,10 +17,11 @@ class TaskLoopForIOLinux : public TaskLoop {
   // descriptor can be read from.
   class SocketReader {
    public:
-    SocketReader(int fd): fd_(fd) {}
+    SocketReader(int fd) : fd_(fd) {}
     virtual ~SocketReader() = default;
     int Socket() { return fd_; }
     virtual void OnCanReadFromSocket() = 0;
+
    protected:
     int fd_;
   };
@@ -84,6 +85,6 @@ class TaskLoopForIOLinux : public TaskLoop {
   size_t event_count_ = 1;
 };
 
-} // namespace base
+}  // namespace base
 
-#endif // BASE_SCHEDULING_TASK_LOOP_FOR_IO_LINUX_H_
+#endif  // BASE_SCHEDULING_TASK_LOOP_FOR_IO_LINUX_H_

--- a/base/scheduling/task_loop_for_io_linux.h
+++ b/base/scheduling/task_loop_for_io_linux.h
@@ -1,0 +1,130 @@
+#ifndef BASE_SCHEDULING_TASK_LOOP_FOR_IO_LINUX_H_
+#define BASE_SCHEDULING_TASK_LOOP_FOR_IO_LINUX_H_
+
+#include <stdint.h>
+#include <sys/epoll.h>
+#include <sys/errno.h>
+#include <sys/eventfd.h>
+
+#include <map>
+#include <queue>
+#include <vector>
+
+#include "base/callback.h"
+#include "base/scheduling/task_loop.h"
+#include "base/synchronization/mutex.h"
+
+#define MAX_EVENTS 10
+
+namespace base {
+
+class TaskLoopForIOLinux : public TaskLoop {
+ public:
+  // |SocketReader|s register themselves with a |TaskLoopForIO| associated with
+  // a given file descriptor. They are notified asynchronously when the file
+  // descriptor can be read from.
+  class SocketReader {
+   public:
+    SocketReader(int fd): fd_(fd) {}
+    virtual ~SocketReader() = default;
+    int Socket() { return fd_; }
+    virtual void OnCanReadFromSocket() = 0;
+   protected:
+    int fd_;
+  };
+
+  TaskLoopForIOLinux();
+  ~TaskLoopForIOLinux();
+
+  TaskLoopForIOLinux(TaskLoopForIOLinux&) = delete;
+  TaskLoopForIOLinux(TaskLoopForIOLinux&&) = delete;
+  TaskLoopForIOLinux& operator=(const TaskLoopForIOLinux&) = delete;
+
+  // Thread::Delegate implementation.
+  void Run() override;
+  // Can be called from any thread.
+  void Quit() override;
+
+  // TaskRunner::Delegate implementation.
+  // Can be called from any thread.
+  void PostTask(OnceClosure cb) override;
+
+  void QuitWhenIdle() override;
+
+  // Can be called from any thread.
+  void WatchSocket(SocketReader* reader);
+  void UnwatchSocket(SocketReader* reader);
+
+  // Can be called from any thread (it is *implicitly* thread-safe).
+  void Wakeup();
+
+ private:
+  int epollfd_;
+  int eventfd_wakeup_;
+
+  // The kqueue that drives the task loop. This is only written to once on
+  // whatever thread |this| loop is constructed on (note this may be different
+  // than the thread it is ultimately bound to). Can be read from any thread.
+  //const int kqueue_;
+
+  // Receive right to which an empty Mach message is sent to wake up the loop
+  // in response to |PostTask()|.
+  //mach_port_t wakeup_;
+  // Scratch buffer that is used to receive the message sent to |wakeup_|.
+  //mach_msg_empty_rcv_t wakeup_buffer_;
+
+  // These are listeners that get notified when their file descriptor has been
+  // written to and is ready to read from. |SocketReader|s are expected to
+  // unregister themselves from this map upon destruction.
+  // This data structure is guarded by |mutex_| as it can be written to from any
+  // thread interacting with |this|.
+  std::map<int, SocketReader*> async_socket_readers_;
+
+  // NOTE ABOUT THREAD SAFETY:
+  //   * The below |event_count_| can be modified from any thread that interacts
+  //     with |this| loop, and therefore its writes are guarded by |mutex_| so
+  //     that all writes persist.
+  //   * The below |events_| is only ever written to and read from the thread
+  //     that |this| loop is bound to, in the Run() method.
+  //   * Reading from these variables does not need to be synchronized. In
+  //     Run(), we read from |event_count_| to resize |events_|. You can imagine
+  //     that once we read |event_count_| to resize |events_| (for submission to
+  //     `kevent64()`), we're only taking a snapshot of the value. It could have
+  //     changed by the time we _actually_ call `kevent64()` to wait for events,
+  //     to either greater or less than the one we snapshotted. Let's consider
+  //     each case separately.
+  //       1.) Value was increased after snapshot:
+  //           For example, we enter the loop in Run() with |event_count_| set
+  //           to 4 (three socket readers + our wakeup event). We resize
+  //           |events_| accordingly, but before we call `kevent64()` to wait
+  //           for at most 4 events, two more readers are added, and the actual
+  //           value of |event_count_| gets updated to 6 and the underlying
+  //           kernel queue knows about 6 possible event sources. We call
+  //           `kevent64()` with the argument `num_events=4`, meaning we'll
+  //           return with at 4 events ready to process from the 6 event
+  //           sources. This is totally valid! The kqueue system actually lets
+  //           you process a single event at a time with num_events=1 if you
+  //           want, it's just less efficient.
+  //       2.) Value was decreased after snapshot:
+  //           Similar to the above example, we invoke `kevent64()` with
+  //           `num_events=x` even though the number of event sources that the
+  //           underlying kernel queue actually knows about is x-2, for example.
+  //           In this case, the number of events we are willing to accept is
+  //           larger than the number of events the kernel queue will ever
+  //           produce, which is also fine. You can try setting |event_count_|
+  //           to an absurdly high number below and running the tests.
+  // END NOTE
+  // The number of event types (filters) that we're interested in listening to
+  // via |kqueue_|. There is always at least 1, for the |wakeup_| port (or
+  // |port_set_|), but increase this count whenever we register a new e.g.,
+  // |SocketReader|.
+  size_t event_count_ = 1;
+  // This buffer is where events from the kernel queue are stored after calls to
+  // |kevent64|. This buffer is consulted in |Run()|, where events are pulled
+  // and the loop responds to them.
+  std::vector<struct epoll_event> events_{event_count_};
+};
+
+} // namespace base
+
+#endif // BASE_SCHEDULING_TASK_LOOP_FOR_IO_LINUX_H_

--- a/base/scheduling/task_loop_for_io_mac.h
+++ b/base/scheduling/task_loop_for_io_mac.h
@@ -17,10 +17,7 @@
 namespace base {
 
 // Note that this |TaskLoop| variant only works on macOS, as it uses Mach ports
-// and |kevent64()| to block on OS-level IPC primitives. Once we support
-// detecting which platform we're on, we'll need to make an equivalent class
-// that uses glib, libevent, or something for Linux, and ensure that we
-// instantiate the correct one depending on the platform we're running on.
+// and |kevent64()| to block on OS-level IPC primitives.
 class TaskLoopForIOMac : public TaskLoop {
  public:
   // |SocketReader|s register themselves with a |TaskLoopForIO| associated with

--- a/base/scheduling/task_loop_for_io_test.cc
+++ b/base/scheduling/task_loop_for_io_test.cc
@@ -57,7 +57,7 @@ class TaskLoopForIOTestBase : public testing::Test {
 
   void OnMessageRead(std::string message) {
     messages_read.push_back(message);
-    if (messages_read.size() == expected_message_count_)
+    if ((int)messages_read.size() == expected_message_count_)
       task_loop_for_io->Quit();
   }
 

--- a/base/scheduling/task_loop_test.cc
+++ b/base/scheduling/task_loop_test.cc
@@ -336,17 +336,9 @@ TEST_P(TaskLoopTest, QuitWhenIdleMidTask) {
 }
 
 
-#if defined(OS_MACOS)
 INSTANTIATE_TEST_SUITE_P(All,
                          TaskLoopTest,
                          testing::Values(ThreadType::UI, ThreadType::IO, ThreadType::WORKER),
                          &TaskLoopTest::DescribeParams);
-#else
-// ThreadType::IO is only supported on macos for now.
-INSTANTIATE_TEST_SUITE_P(All,
-                         TaskLoopTest,
-                         testing::Values(ThreadType::UI, ThreadType::WORKER),
-                         &TaskLoopTest::DescribeParams);
-#endif
 
 }; // namespace base

--- a/base/threading/thread_test.cc
+++ b/base/threading/thread_test.cc
@@ -224,17 +224,9 @@ TEST_P(ThreadTest, StopWhenIdleRunsQueuedTasks) {
   EXPECT_TRUE(second_task_ran);
 }
 
-#if defined(OS_MACOS)
 INSTANTIATE_TEST_SUITE_P(All,
                          ThreadTest,
                          testing::Values(ThreadType::UI, ThreadType::IO, ThreadType::WORKER),
                          &ThreadTest::DescribeParams);
-#else
-// ThreadType::IO is only supported on macos for now.
-INSTANTIATE_TEST_SUITE_P(All,
-                         ThreadTest,
-                         testing::Values(ThreadType::UI, ThreadType::WORKER),
-                         &ThreadTest::DescribeParams);
-#endif
 
 }; // namespace base

--- a/base/threading/thread_test.cc
+++ b/base/threading/thread_test.cc
@@ -25,6 +25,9 @@ class ThreadTest : public testing::Test,
       case ThreadType::WORKER:
         return "WORKER";
     }
+
+    NOTREACHED();
+    return "NOTREACHED";
   }
 
   void SetUp() override {


### PR DESCRIPTION
TaskLoopForIO was first introduced in https://github.com/domfarolino/browser/pull/25, with the macOS implementation based on [kqueue](https://www.freebsd.org/cgi/man.cgi?query=kqueue) for BSD operating systems.

Since there was no implementation for Linux, all tests that exercised TaskLoopForIO had to be disabled for Linux. This PR implements TaskLoopForIO on Linux (concretely, `TaskLoopForIOLinux`) and enables the entire `base_tests` suite for that platform. TaskLoopForIOLinux is based on [epoll](https://man7.org/linux/man-pages/man7/epoll.7.html), and has been implemented to have identical IO reading and wakeup semantics to TaskLoopForIOMac.

This PR is based on top of @pmusgrave's heroic work in https://github.com/domfarolino/browser/pull/53, which has been stalled. I'll close that PR and continue the implementation over here, as it is currently blocking the mage IPC implementation in #32.

----

Closes https://github.com/domfarolino/browser/issues/33.