### PR TITLE
Reorder operations in TaskLoopForIO::WatchSocket()

### DIFF
--- a/base/scheduling/task_loop_for_io_linux.cc
+++ b/base/scheduling/task_loop_for_io_linux.cc
@@ -100,15 +100,6 @@ void TaskLoopForIOLinux::WatchSocket(SocketReader* socket_reader) {
   CHECK(socket_reader);
   int fd = socket_reader->Socket();
 
-  epoll_data_t event_data;
-  event_data.fd = fd;
-  struct epoll_event ev;
-  ev.events = EPOLLIN;
-  ev.data = event_data;
-
-  int rv = epoll_ctl(epollfd_, EPOLL_CTL_ADD, fd, &ev);
-  CHECK_NE(rv, -1);
-
   mutex_.lock();
   // A socket reader can only be registered once.
   CHECK_EQ(async_socket_readers_.find(fd), async_socket_readers_.end());
@@ -118,6 +109,15 @@ void TaskLoopForIOLinux::WatchSocket(SocketReader* socket_reader) {
   // Protect against overflow.
   CHECK_GE(event_count_, 1);
   mutex_.unlock();
+
+  epoll_data_t event_data;
+  event_data.fd = fd;
+  struct epoll_event ev;
+  ev.events = EPOLLIN;
+  ev.data = event_data;
+
+  int rv = epoll_ctl(epollfd_, EPOLL_CTL_ADD, fd, &ev);
+  CHECK_NE(rv, -1);
 }
 
 void TaskLoopForIOLinux::UnwatchSocket(SocketReader* socket_reader) {


### PR DESCRIPTION
This commit reorders the operations in TaskLoopForIO::WatchSocket() from being:

 1. Register the socket with the kernel
 1. Add the socket reader to the socket reader list

... to the exact opposite of this. If `WatchSocket()` was called on a thread different from the IO thread, then the socket might become readable from the IO thread's `Run()` method before the socket is registered in the list, causing the IO thread's `Run()` crash when it tries to look up the associated socket reader from the internal list.

In reality, we should probably just CHECK that WatchSocket() is called on the IO thread instead of any other thread, but for now this will do.