### PR TITLE
Fix BUILD for bazel 6

### DIFF
--- a/base/BUILD
+++ b/base/BUILD
@@ -2,12 +2,12 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 config_setting(
   name = "mac",
-  constraint_values = ["@bazel_tools//platforms:osx"],
+  constraint_values = ["@platforms//os:osx"],
 )
 
 config_setting(
   name = "linux",
-  constraint_values = ["@bazel_tools//platforms:linux"],
+  constraint_values = ["@platforms//os:linux"],
 )
 
 cc_library(


### PR DESCRIPTION
Until the browser repository moves to using `//base` as an external dependency (provided by https://github.com/domfarolino/base), we'll need to update the hermetic `//base` directory's BUILD file to be compatible with bazel 6, which runs on the GitHub actions bots. This is the same as https://github.com/domfarolino/base/pull/6.